### PR TITLE
[MRG+2] pypy3 7.1.1 -> 7.3.0

### DIFF
--- a/circle-pypy-base/Dockerfile
+++ b/circle-pypy-base/Dockerfile
@@ -1,7 +1,7 @@
 # Not used in this build
 ARG PMDARIMA_VSN
 
-FROM pypy:3.6-7.3.0
+FROM pypy:3.6-7.3.0-slim-stretch
 
 # https://stackoverflow.com/a/25423366/3015734
 SHELL ["/bin/bash", "-c"]

--- a/circle-pypy-base/Dockerfile
+++ b/circle-pypy-base/Dockerfile
@@ -1,7 +1,7 @@
 # Not used in this build
 ARG PMDARIMA_VSN
 
-FROM pypy:3.6-7.1.1
+FROM pypy:3.6-7.3.0
 
 # https://stackoverflow.com/a/25423366/3015734
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
I had to bump the pypy version in alkaline-ml/pmdarima#334. I think I need to bump it here to get the pypy build in that PR to pass