### PR TITLE
[MRG] Don't use slim container

### DIFF
--- a/circle-pypy-base/Dockerfile
+++ b/circle-pypy-base/Dockerfile
@@ -1,7 +1,7 @@
 # Not used in this build
 ARG PMDARIMA_VSN
 
-FROM pypy:3.6-7.3.0-slim-stretch
+FROM pypy:3.6-7.3.0-stretch
 
 # https://stackoverflow.com/a/25423366/3015734
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
The slim container leaves out `libfreetype6-dev` _and_ causes matplotlib tests to fail, so we are just going to do away with it.

Tested by running the build pipeline (including tests) in the non-slim container