### PR TITLE
[MRG+1] Fix bot

### DIFF
--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 7 * * *'  # Every day at 07:00 UTC (1AM CST or 2AM CDT)
 
-  # Run if we edit this file
-  push:
-    paths:
-      - '.github/workflows/keep_docker_in_sync.yml'
-
 jobs:
   keep-docker-in-sync:
     name: Check for Latest Version

--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -72,5 +72,5 @@ jobs:
           branch-suffix: random
 
       - name: Check outputs
-        if: ${{ success() && steps.pypi_version_check.outputs.pypi_version != steps.docker_version_check.outputs.docker_version && !steps.pr_check.outputs.pr_exists }}
+        if: ${{ success() && steps.pypi_version_check.outputs.pypi_version != steps.docker_version_check.outputs.docker_version && steps.pr_check.outputs.pr_exists != 'true' }}
         run: echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"

--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -45,7 +45,7 @@ jobs:
           echo "::set-output name=pr_exists::$output"
 
       - name: Find Docker version
-        if: steps.pr_check.outputs.pr_exists != "true"
+        if: ${{ steps.pr_check.outputs.pr_exists != "true" }}
         id: docker_version_check  # Need this to refer to output below
         run: |
           output=($(cat common/build.mk | grep "PMDARIMA_VSN :="))

--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -45,7 +45,7 @@ jobs:
           echo "::set-output name=pr_exists::$output"
 
       - name: Find Docker version
-        if: ${{ steps.pr_check.outputs.pr_exists != "true" }}
+        if: ${{ steps.pr_check.outputs.pr_exists != 'true' }}
         id: docker_version_check  # Need this to refer to output below
         run: |
           output=($(cat common/build.mk | grep "PMDARIMA_VSN :="))

--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -45,7 +45,7 @@ jobs:
           echo "::set-output name=pr_exists::$output"
 
       - name: Find Docker version
-        if: ${{ !steps.pr_check.outputs.pr_exists }}
+        if: steps.pr_check.outputs.pr_exists != "false"
         id: docker_version_check  # Need this to refer to output below
         run: |
           output=($(cat common/build.mk | grep "PMDARIMA_VSN :="))

--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -52,11 +52,11 @@ jobs:
           echo "::set-output name=docker_version::${output[2]}"
 
       - name: Update version in Docker
-        if: ${{ steps.pypi_version_check.outputs.pypi_version != steps.docker_version_check.outputs.docker_version && !steps.pr_check.outputs.pr_exists }}
+        if: ${{ steps.pypi_version_check.outputs.pypi_version != steps.docker_version_check.outputs.docker_version && steps.pr_check.outputs.pr_exists != 'true' }}
         run: sed -i "9s/.*/PMDARIMA_VSN := ${{ steps.pypi_version_check.outputs.pypi_version }}/" common/build.mk
 
       - name: Create Pull Request
-        if: ${{ success() && steps.pypi_version_check.outputs.pypi_version != steps.docker_version_check.outputs.docker_version && !steps.pr_check.outputs.pr_exists }}
+        if: ${{ success() && steps.pypi_version_check.outputs.pypi_version != steps.docker_version_check.outputs.docker_version && steps.pr_check.outputs.pr_exists != 'true' }}
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Bump pmdarima version

--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 7 * * *'  # Every day at 07:00 UTC (1AM CST or 2AM CDT)
 
+  # Run if we edit this file
+  push:
+    paths:
+      - '.github/workflows/keep_docker_in_sync.yml'
+
 jobs:
   keep-docker-in-sync:
     name: Check for Latest Version
@@ -16,7 +21,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setting up Python
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
           architecture: x64
@@ -52,7 +57,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ success() && steps.pypi_version_check.outputs.pypi_version != steps.docker_version_check.outputs.docker_version && !steps.pr_check.outputs.pr_exists }}
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Bump pmdarima version
           title: 'Version ${{ steps.pypi_version_check.outputs.pypi_version }}'

--- a/.github/workflows/keep_docker_in_sync.yml
+++ b/.github/workflows/keep_docker_in_sync.yml
@@ -45,7 +45,7 @@ jobs:
           echo "::set-output name=pr_exists::$output"
 
       - name: Find Docker version
-        if: steps.pr_check.outputs.pr_exists != "false"
+        if: steps.pr_check.outputs.pr_exists != "true"
         id: docker_version_check  # Need this to refer to output below
         run: |
           output=($(cat common/build.mk | grep "PMDARIMA_VSN :="))


### PR DESCRIPTION
The bot was silently failing because apparently the `!condition` syntax was deprecated. This PR bumps some versions and changes all of the places where we use that syntax to `condition != 'true'` 🤮 