### PR TITLE
Bump version of doc-base

### DIFF
--- a/cpython/Dockerfile
+++ b/cpython/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 ARG PMDARIMA_VSN
 
 RUN pip install pmdarima==${PMDARIMA_VSN}

--- a/doc-base/Dockerfile
+++ b/doc-base/Dockerfile
@@ -1,7 +1,7 @@
 # Not used in this build
 ARG PMDARIMA_VSN
 
-FROM python:3.7
+FROM python:3.9
 
 # https://stackoverflow.com/a/25423366/3015734
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
Bump from python 3.7 -> 3.9 for `doc-base` image.